### PR TITLE
fix: bug with search

### DIFF
--- a/apps/frontend/src/components/command/CommandBody.vue
+++ b/apps/frontend/src/components/command/CommandBody.vue
@@ -37,7 +37,7 @@ watchDebounced(() => searchWord.value, async (v) => {
       isReset.value = false
     await showComponentAndHandle.value[1](v)
   }
-}, { debounce: 175 })
+}, { debounce: 500 })
 
 watch(() => searchWord.value, (v) => {
   if (v === '') {

--- a/apps/frontend/src/store/useSearch.ts
+++ b/apps/frontend/src/store/useSearch.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, watch } from 'vue'
+import { ref } from 'vue'
 import Fuse from 'fuse.js'
 import { TaskState, getTaskFromProject, loadAllTasksNotRemoved } from 'services/task'
 import type { ListProject, SmartProject } from 'services/task'
@@ -21,18 +21,9 @@ export const useSearchStore = defineStore('searchStore', () => {
     keys: ['title', 'desc'],
   })
 
-  watch(
-    () => allTasks.value,
-    (v) => {
-      if (v && v.length)
-        fuse.setCollection(v)
-    },
-    { immediate: true },
-  )
-
   function collectAllTasks() {
     allTasks.value = []
-    loadAllTasksNotRemoved().then((tasks) => {
+    return loadAllTasksNotRemoved().then((tasks) => {
       tasks.forEach((task) => {
         allTasks.value.push({
           id: task.id!,
@@ -46,9 +37,8 @@ export const useSearchStore = defineStore('searchStore', () => {
     })
   }
 
-  collectAllTasks()
-
-  const handleSearch = (input: string) => {
+  const handleSearch = async (input: string) => {
+    await collectAllTasks()
     searchTasks.value = fuse.search(input)
   }
 


### PR DESCRIPTION
1. fix: fix the error reported when typing quickly on the command panel
问题：search 快速输入一些内容时，组件的ref会丢失，产生报错
修复：适当增加了watchDebounced的间隔时间
位置：src/components/command/CommandBody.vue
- before
![20230113searcherror](https://user-images.githubusercontent.com/41691876/212233845-9c059594-9c67-4652-9728-8683123958fe.gif)
![20230113searcherror2](https://user-images.githubusercontent.com/41691876/212233850-b827ffa7-44f1-4183-9305-ca41e0190995.gif)
- after
![20230113fixsearcherror](https://user-images.githubusercontent.com/41691876/212234447-cbf0da18-3c21-4115-a5be-62c63f2bb35e.gif)

2. fix: fix the search problem caused by collectAllTasks will only be executed once
问题：例如在生活中有吃饭，当已完成时，搜索吃饭，搜索结果中的状态还是未完成状态。没有更新任务的状态。
修复：修改了 collectAllTasks 的调用位置，搜索前获取当前最新的alltask
位置：apps/frontend/src/store/useSearch.ts
- before
![20230116b](https://user-images.githubusercontent.com/41691876/212609416-9b16c3d4-ffbf-4acf-90cf-5f8a75c3d9c2.gif)
- after
![20230116a](https://user-images.githubusercontent.com/41691876/212609509-9f00eae6-9c87-4bd3-8eb7-b1fb53d81739.gif)
